### PR TITLE
Fix incorrect Slack notification Badge

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -36,7 +36,7 @@ const SELECTOR_CHANNELS_UNREAD = '.p-channel_sidebar__channel--unread:not(.p-cha
 
 module.exports = (Franz) => {
   const getMessages = () => {
-    const directMessages = document.querySelectorAll(`${SELECTOR_CHANNELS_UNREAD} .p-channel_sidebar__badge, .p-channel_sidebar__link--unread`).length;
+    const directMessages = document.querySelectorAll(`${SELECTOR_CHANNELS_UNREAD} .p-channel_sidebar__badge, .p-channel_sidebar__link--unread:not([data-sidebar-link-id="Punreads"]`).length;
     const allMessages = document.querySelectorAll(SELECTOR_CHANNELS_UNREAD).length - directMessages;
 
     // set Franz badge


### PR DESCRIPTION
Currently slack will show 1 notification even if there are zero. This is due to a code change in Slack.

I changed the current CSS selector ignore the "All Unreads" channel.