### PR TITLE
Fix slack icon updating

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -5,7 +5,7 @@ const getTeamIcon = function getTeamIcon(count = 0) {
   let countTeamIconCheck = count;
   let bgUrl = null;
 
-  const teamMenu = document.querySelector('#team-menu-trigger');
+  const teamMenu = document.querySelector('[data-qa=team-menu-trigger],#team-menu-trigger');
   if (teamMenu) {
     teamMenu.click();
 


### PR DESCRIPTION
The redesigned slack UI has a slightly different DOM. The team-menu-trigger is no longer tagged with id but instead with the data-qa attribute. I've adjusted the document.querySelector call so that it works with either the old or new style attributes.